### PR TITLE
Add option to json_decode into associative array if '$type' is array.…

### DIFF
--- a/src/DataConverter/JsonConverter.php
+++ b/src/DataConverter/JsonConverter.php
@@ -83,7 +83,12 @@ class JsonConverter extends Converter
     public function fromPayload(Payload $payload, Type $type)
     {
         try {
-            $data = \json_decode($payload->getData(), false, 512, self::JSON_FLAGS);
+            $data = \json_decode(
+                $payload->getData(),
+                $type->getName() === Type::TYPE_ARRAY,
+                512,
+                self::JSON_FLAGS
+            );
         } catch (\Throwable $e) {
             throw new DataConverterException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/DataConverter/Type.php
+++ b/src/DataConverter/Type.php
@@ -107,7 +107,7 @@ final class Type
             }
 
             // Traversable types (i.e. Generator) not allowed
-            if (!$name instanceof \Traversable && $name !== 'array' && $name !== 'iterable') {
+            if (!$name instanceof \Traversable && $name !== 'iterable') {
                 return new self($type->getName(), $type->allowsNull());
             }
         }

--- a/tests/Unit/DataConverter/DataConverterTestCase.php
+++ b/tests/Unit/DataConverter/DataConverterTestCase.php
@@ -45,6 +45,8 @@ class DataConverterTestCase extends UnitTestCase
             Type::TYPE_INT    => [Type::TYPE_INT, 42],
             Type::TYPE_FLOAT  => [Type::TYPE_FLOAT, 0.1],
             Type::TYPE_VOID   => [Type::TYPE_VOID, null],
+
+            Type::TYPE_ARRAY . ' (associative)  => ' . Type::TYPE_ARRAY => [Type::TYPE_ARRAY, ['field' => 'value']],
         ];
     }
 
@@ -89,7 +91,6 @@ class DataConverterTestCase extends UnitTestCase
             Type::TYPE_BOOL . ' => ' . Type::TYPE_OBJECT   => [Type::TYPE_OBJECT, true],
             Type::TYPE_VOID . ' => ' . Type::TYPE_OBJECT   => [Type::TYPE_OBJECT, null],
 
-            Type::TYPE_OBJECT . ' => ' . Type::TYPE_ARRAY => [Type::TYPE_ARRAY, (object)['field' => 'value']],
             Type::TYPE_FLOAT . ' => ' . Type::TYPE_ARRAY  => [Type::TYPE_ARRAY, .42],
             Type::TYPE_INT . ' => ' . Type::TYPE_ARRAY    => [Type::TYPE_ARRAY, 42],
             Type::TYPE_STRING . ' => ' . Type::TYPE_ARRAY => [Type::TYPE_ARRAY, 'string'],


### PR DESCRIPTION
… Remove 'array' from forbidden types.